### PR TITLE
Redesign site as a single-page layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,150 @@
+:root {
+  --navy: #0f172a;
+  --light-navy: #112240;
+  --lightest-navy: #233554;
+  --white: #e6f1ff;
+  --slate: #8892b0;
+  --light-slate: #ccd6f6;
+  --green: #64ffda;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: var(--navy);
+  color: var(--white);
+  line-height: 1.6;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  backdrop-filter: blur(10px);
+  background-color: rgba(15, 23, 42, 0.8);
+  z-index: 100;
+}
+
+nav {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+nav a {
+  color: var(--light-slate);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--green);
+}
+
+.toggle {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.toggle span {
+  width: 24px;
+  height: 2px;
+  background: var(--light-slate);
+}
+
+section {
+  padding: 100px 20px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.hero {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.hero h1 {
+  color: var(--green);
+  margin: 0 0 20px 0;
+}
+
+.hero h2 {
+  font-size: clamp(40px, 8vw, 80px);
+  margin: 0 0 20px 0;
+}
+
+.btn {
+  display: inline-block;
+  border: 1px solid var(--green);
+  color: var(--green);
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.btn:hover,
+.btn:focus {
+  background: rgba(100, 255, 218, 0.1);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.card {
+  background: var(--light-navy);
+  padding: 1rem;
+  border-radius: 8px;
+}
+
+@media (max-width: 600px) {
+  .toggle {
+    display: flex;
+  }
+
+  nav ul {
+    position: absolute;
+    top: 60px;
+    right: 20px;
+    flex-direction: column;
+    background: rgba(15,23,42,0.9);
+    padding: 1rem;
+    border-radius: 8px;
+    display: none;
+  }
+
+  nav.open ul {
+    display: flex;
+  }
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 0;
+  font-size: 0.9rem;
+  color: var(--slate);
+}

--- a/index.html
+++ b/index.html
@@ -1,67 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title>His Page</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- CSS -->
-    <link rel="stylesheet" href="css/global.css">
-    <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/home.css">
-    <link rel="stylesheet" href="css/education.css">
-    <link rel="stylesheet" href="css/research.css">
-    <link rel="stylesheet" href="css/teaching.css">
-    <link rel="stylesheet" href="css/projects.css">
-    <link rel="stylesheet" href="css/contact.css">
-    <!-- Google Fonts & GSAP -->
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.11.5/gsap.min.js"></script>
-    <script defer src="js/app.js"></script>
-  </head>
-  <body>
-    <header class="top-nav">
-      <div class="nav-left">
-        <a href="#" class="site-title" data-page="home">Hisu Kim</a>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hisu Kim</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="#home" class="logo">Hisu Kim</a>
+      <div class="toggle" aria-label="Toggle navigation" tabindex="0">
+        <span></span><span></span><span></span>
       </div>
+      <ul>
+        <li><a href="#home">Home</a></li>
+        <li><a href="#education">Education</a></li>
+        <li><a href="#research">Research</a></li>
+        <li><a href="#teaching">Teaching</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
 
-      <nav class="nav-right" id="navbar">
-        <ul>
-          <li>
-            <a href="#" data-page="home" class="nav-link">Home</a>
-          </li>
-          <li>
-            <a href="#" data-page="education" class="nav-link">Education</a>
-          </li>
-          <li>
-            <a href="#" data-page="research" class="nav-link">Research</a>
-          </li>
-          <li>
-            <a href="#" data-page="teaching" class="nav-link">Teaching</a>
-          </li>
-          <li>
-            <a href="#" data-page="projects" class="nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="#" data-page="contact" class="nav-link">Contact</a>
-          </li>
-        </ul>
-        <span class="nav-indicator"></span>
-      </nav>
+  <main>
+    <section id="home" class="hero" aria-label="Hero" >
+      <div id="home-section"></div>
+    </section>
 
-      <!-- 햄버거 아이콘은 nav 바깥으로 명시적으로 추가 -->
-      <div class="hamburger" id="hamburger">
-        <span></span>
-        <span></span>
-        <span></span>
-      </div>
-    </header>
+    <section id="education" aria-label="Education">
+      <h2>Education</h2>
+      <div id="education-list" class="grid"></div>
+    </section>
 
-    <main id="main-content"></main>
+    <section id="research" aria-label="Research">
+      <h2>Publications</h2>
+      <div id="pub-list"></div>
+      <h2>Experience</h2>
+      <div id="exp-list" class="grid"></div>
+    </section>
 
-    <footer class="footer">
-      <p>&copy; 2025 Hisu Kim. All rights reserved.</p>
-    </footer>
-    
-  </body>
+    <section id="teaching" aria-label="Teaching">
+      <h2>Teaching</h2>
+      <div id="teaching-list" class="grid"></div>
+    </section>
+
+    <section id="projects" aria-label="Projects">
+      <h2>Projects</h2>
+      <div id="project-grid" class="grid"></div>
+    </section>
+
+    <section id="contact" aria-label="Contact">
+      <h2>Contact</h2>
+      <p>Email: <a href="mailto:tomm1203@gist.ac.kr">tomm1203@gist.ac.kr</a></p>
+      <p>GitHub: <a href="https://github.com/HisKim1" target="_blank" rel="noopener noreferrer">github.com/HisKim1</a></p>
+    </section>
+  </main>
+
+  <footer>
+    Built by Hisu Kim on GitHub Pages
+  </footer>
+
+  <script src="js/main.js"></script>
+</body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,83 @@
+async function fetchJSON(path) {
+  const res = await fetch(path);
+  return res.json();
+}
+
+function initNavigation() {
+  const toggle = document.querySelector('.toggle');
+  const nav = document.querySelector('nav');
+  if (toggle) {
+    toggle.addEventListener('click', () => nav.classList.toggle('open'));
+  }
+}
+
+function createTagHTML(tag) {
+  return `<span class="tag">${tag}</span>`;
+}
+
+function generateHome(data) {
+  const container = document.getElementById('home-section');
+  if (!container) return;
+  container.innerHTML = `
+    <div class="hero">
+      <h1>Hello, my name is</h1>
+      <h2>${data.profile.name}</h2>
+      <p>${data.academic.paragraphs[0]}</p>
+      <a class="btn" href="#contact">Get In Touch</a>
+    </div>
+  `;
+}
+
+function generateEducation(data) {
+  const list = document.getElementById('education-list');
+  if (!list) return;
+  let html = '';
+  data.main.forEach(item => {
+    html += `<div class="card"><h3>${item.school}</h3><p>${item.degree || ''} ${item.minor || ''}</p><p>${item.period}</p></div>`;
+  });
+  list.innerHTML = html;
+}
+
+function generateProjects(data) {
+  const grid = document.getElementById('project-grid');
+  if (!grid) return;
+  grid.innerHTML = data.map(p => `
+    <div class="card">
+      <img src="${p.images}" alt="${p.title}" style="width:100%;border-radius:4px;">
+      <h3>${p.title}</h3>
+      <p>${p.description}</p>
+    </div>
+  `).join('');
+}
+
+function generateTeaching(data) {
+  const grid = document.getElementById('teaching-list');
+  if (!grid) return;
+  grid.innerHTML = data.map(t => `
+    <div class="card"><h3>${t.title}</h3>${t.description}</div>
+  `).join('');
+}
+
+function generateResearch(data) {
+  const pub = document.getElementById('pub-list');
+  const exp = document.getElementById('exp-list');
+  if (pub) {
+    pub.innerHTML = '<ul>' + data.publications.map(p => `<li>${p.authors || ''} ${p.title || ''}</li>`).join('') + '</ul>';
+  }
+  if (exp) {
+    exp.innerHTML = data.experience.map(e => `
+      <div class="card"><h3>${e.lab}</h3><p>${e.position}</p><p>${e.period}</p></div>
+    `).join('');
+  }
+}
+
+async function init() {
+  initNavigation();
+  generateHome(await fetchJSON('data/home.json'));
+  generateEducation(await fetchJSON('data/education.json'));
+  generateProjects(await fetchJSON('data/projects.json'));
+  generateTeaching(await fetchJSON('data/teaching.json'));
+  generateResearch(await fetchJSON('data/research.json'));
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- drop page-by-page navigation for a single scrolling page
- add new style sheet using dark navy palette
- create simple JS to load content from JSON

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881d4152aa0832abde5670f73ce4308