### PR TITLE
Refine site layout and styling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,227 @@
+:root {
+  --navy: #0f172a;
+  --light-navy: #112240;
+  --lightest-navy: #233554;
+  --white: #e6f1ff;
+  --slate: #8892b0;
+  --light-slate: #ccd6f6;
+  --accent: #4ade80;
+  --cursor-x: 50vw;
+  --cursor-y: 50vh;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Open Sans', 'Helvetica Neue', sans-serif;
+  background-color: var(--navy);
+  /* subtle geometric background */
+  background-attachment: fixed;
+  color: var(--white);
+  line-height: 1.6;
+}
+
+body::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: radial-gradient(circle at var(--cursor-x) var(--cursor-y), rgba(255,255,255,0.15), transparent 50%);
+  mix-blend-mode: screen;
+  z-index: -1;
+}
+
+body::after {
+  content: "";
+  position: fixed;
+  inset: 0;
+  pointer-events: none;
+  background: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Cpolygon fill='%23ffffff' points='50,5 90,30 90,70 50,95 10,70 10,30'/%3E%3C/svg%3E") no-repeat center/80vmin;
+  opacity: 0.06;
+  transform: scale(1.1) rotate(5deg);
+  z-index: -2;
+  background-attachment: fixed;
+}
+
+header {
+  position: fixed;
+  top: 0;
+  width: 100%;
+  backdrop-filter: blur(10px);
+  background-color: rgba(15, 23, 42, 0.5);
+  z-index: 100;
+}
+
+nav {
+  max-width: 900px;
+  margin: 0 auto;
+  padding: 1rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+nav a {
+  color: var(--light-slate);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+nav a:hover,
+nav a:focus {
+  color: var(--accent);
+}
+
+.toggle {
+  display: none;
+  flex-direction: column;
+  gap: 4px;
+  cursor: pointer;
+}
+
+.toggle span {
+  width: 24px;
+  height: 2px;
+  background: var(--light-slate);
+}
+
+section {
+  padding: 100px 20px;
+  max-width: 900px;
+  margin: 0 auto;
+}
+
+.hero {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  text-align: center;
+}
+
+.hero .profile-img {
+  width: 220px;
+  height: 220px;
+  border-radius: 50%;
+  border: 3px solid var(--accent);
+  object-fit: cover;
+  margin: 0 auto 1rem;
+}
+
+.hero h1 {
+  color: var(--accent);
+  margin: 0 0 20px 0;
+}
+
+.hero h2 {
+  font-size: clamp(40px, 8vw, 80px);
+  margin: 0 0 20px 0;
+}
+
+.btn {
+  display: inline-block;
+  border: 1px solid var(--accent);
+  color: var(--accent);
+  padding: 0.75rem 1.5rem;
+  border-radius: 4px;
+  background: transparent;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+.btn:hover,
+.btn:focus {
+  background: rgba(74, 222, 128, 0.1);
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1.5rem;
+}
+
+.vertical {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.project-item {
+  display: flex;
+  gap: 1rem;
+  align-items: center;
+}
+
+.project-img {
+  flex-basis: 33%;
+  max-width: 250px;
+  border-radius: 4px;
+}
+
+.project-text {
+  flex: 1;
+}
+
+.card {
+  background: transparent;
+  padding: 0;
+  border-radius: 0;
+  width: 100%;
+}
+
+.social {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  font-size: 2rem;
+}
+
+.social a {
+  color: var(--light-slate);
+  transition: color 0.2s, transform 0.2s;
+}
+
+.social a:hover,
+.social a:focus {
+  color: var(--accent);
+  transform: translateY(-3px);
+}
+
+@media (max-width: 600px) {
+  .toggle {
+    display: flex;
+  }
+
+  nav ul {
+    position: absolute;
+    top: 60px;
+    right: 20px;
+    flex-direction: column;
+    background: rgba(15,23,42,0.9);
+    padding: 1rem;
+    border-radius: 8px;
+    display: none;
+  }
+
+  nav.open ul {
+    display: flex;
+  }
+}
+
+footer {
+  text-align: center;
+  padding: 2rem 0;
+  font-size: 0.9rem;
+  color: var(--slate);
+}

--- a/index.html
+++ b/index.html
@@ -1,67 +1,70 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title>His Page</title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <!-- CSS -->
-    <link rel="stylesheet" href="css/global.css">
-    <link rel="stylesheet" href="css/components.css">
-    <link rel="stylesheet" href="css/home.css">
-    <link rel="stylesheet" href="css/education.css">
-    <link rel="stylesheet" href="css/research.css">
-    <link rel="stylesheet" href="css/teaching.css">
-    <link rel="stylesheet" href="css/projects.css">
-    <link rel="stylesheet" href="css/contact.css">
-    <!-- Google Fonts & GSAP -->
-    <link rel="preconnect" href="https://fonts.gstatic.com">
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:wght@600;700&family=Roboto:wght@300;400;500&display=swap" rel="stylesheet">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/gsap/3.11.5/gsap.min.js"></script>
-    <script defer src="js/app.js"></script>
-  </head>
-  <body>
-    <header class="top-nav">
-      <div class="nav-left">
-        <a href="#" class="site-title" data-page="home">Hisu Kim</a>
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Hisu Kim</title>
+  <link rel="stylesheet" href="css/style.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+</head>
+<body>
+  <header>
+    <nav>
+      <a href="#home" class="logo">Hisu Kim</a>
+      <div class="toggle" aria-label="Toggle navigation" tabindex="0">
+        <span></span><span></span><span></span>
       </div>
+      <ul>
+        <li><a href="#home">Home</a></li>
+        <li><a href="#education">Education</a></li>
+        <li><a href="#research">Research</a></li>
+        <li><a href="#teaching">Teaching</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#contact">Contact</a></li>
+      </ul>
+    </nav>
+  </header>
 
-      <nav class="nav-right" id="navbar">
-        <ul>
-          <li>
-            <a href="#" data-page="home" class="nav-link">Home</a>
-          </li>
-          <li>
-            <a href="#" data-page="education" class="nav-link">Education</a>
-          </li>
-          <li>
-            <a href="#" data-page="research" class="nav-link">Research</a>
-          </li>
-          <li>
-            <a href="#" data-page="teaching" class="nav-link">Teaching</a>
-          </li>
-          <li>
-            <a href="#" data-page="projects" class="nav-link">Projects</a>
-          </li>
-          <li>
-            <a href="#" data-page="contact" class="nav-link">Contact</a>
-          </li>
-        </ul>
-        <span class="nav-indicator"></span>
-      </nav>
+  <main>
+    <section id="home" class="hero" aria-label="Hero" >
+      <div id="home-section"></div>
+    </section>
 
-      <!-- 햄버거 아이콘은 nav 바깥으로 명시적으로 추가 -->
-      <div class="hamburger" id="hamburger">
-        <span></span>
-        <span></span>
-        <span></span>
+    <section id="education" aria-label="Education">
+      <h2>Education</h2>
+      <div id="education-list" class="vertical"></div>
+    </section>
+
+    <section id="research" aria-label="Research">
+      <h2>Publications</h2>
+      <div id="pub-list"></div>
+      <h2>Experience</h2>
+      <div id="exp-list" class="vertical"></div>
+    </section>
+
+    <section id="teaching" aria-label="Teaching">
+      <h2>Teaching</h2>
+      <div id="teaching-list" class="vertical"></div>
+    </section>
+
+    <section id="projects" aria-label="Projects">
+      <h2>Projects</h2>
+      <div id="project-grid" class="vertical"></div>
+    </section>
+
+    <section id="contact" aria-label="Contact">
+      <h2>Contact</h2>
+      <div class="social">
+        <a href="mailto:tomm1203@gist.ac.kr" aria-label="Email"><i class="fas fa-envelope"></i></a>
+        <a href="https://github.com/HisKim1" target="_blank" rel="noopener noreferrer" aria-label="GitHub"><i class="fab fa-github"></i></a>
       </div>
-    </header>
+    </section>
+  </main>
 
-    <main id="main-content"></main>
+  <footer>
+    Built by Hisu Kim on GitHub Pages
+  </footer>
 
-    <footer class="footer">
-      <p>&copy; 2025 Hisu Kim. All rights reserved.</p>
-    </footer>
-    
-  </body>
+  <script src="js/main.js"></script>
+</body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,116 @@
+async function fetchJSON(path) {
+  const res = await fetch(path);
+  return res.json();
+}
+
+function initNavigation() {
+  const toggle = document.querySelector('.toggle');
+  const nav = document.querySelector('nav');
+  if (toggle) {
+    toggle.addEventListener('click', () => nav.classList.toggle('open'));
+  }
+}
+
+function initSpotlight() {
+  document.addEventListener('mousemove', e => {
+    document.documentElement.style.setProperty('--cursor-x', e.clientX + 'px');
+    document.documentElement.style.setProperty('--cursor-y', e.clientY + 'px');
+  });
+}
+
+function createTagHTML(tag) {
+  return `<span class="tag">${tag}</span>`;
+}
+
+function generateHome(data) {
+  const container = document.getElementById('home-section');
+  if (!container) return;
+  container.innerHTML = `
+    <div class="hero">
+      <img src="${data.profile.img}" alt="${data.profile.name}" class="profile-img">
+      <h1>Hello, my name is</h1>
+      <h2>${data.profile.name}</h2>
+      <p>${data.academic.paragraphs[0]}</p>
+      <a class="btn" href="#contact">Get In Touch</a>
+    </div>
+  `;
+}
+
+function generateEducation(data) {
+  const list = document.getElementById('education-list');
+  if (!list) return;
+  let html = '';
+  data.main.forEach(item => {
+    html += `<div class="card">
+      <h3>${item.school}</h3>
+      <p>${item.degree || ''}${item.minor ? ' • ' + item.minor : ''}</p>
+      <p>${item.period}</p>
+      ${item.tgpa ? `<p>GPA: ${item.tgpa}</p>` : ''}
+      ${item.thesis ? `<p>Thesis: ${item.thesis}</p>` : ''}
+    </div>`;
+  });
+
+  if (data.extracurricular) {
+    html += `<h3>Extracurricular</h3>` + data.extracurricular.map(e => `
+      <div class="card">
+        <h4>${e.school}</h4>
+        <p>${e.period}</p>
+        <p>${e.org}</p>
+      </div>
+    `).join('');
+  }
+
+  list.innerHTML = html;
+}
+
+function generateProjects(data) {
+  const grid = document.getElementById('project-grid');
+  if (!grid) return;
+  grid.innerHTML = data.map(p => `
+    <div class="project-item card">
+      <img class="project-img" src="${p.images}" alt="${p.title}">
+      <div class="project-text">
+        <h3>${p.title}</h3>
+        <p>${p.description}</p>
+      </div>
+    </div>
+  `).join('');
+}
+
+function generateTeaching(data) {
+  const grid = document.getElementById('teaching-list');
+  if (!grid) return;
+  grid.innerHTML = data.map(t => `
+    <div class="card"><h3>${t.title}</h3>${t.description}</div>
+  `).join('');
+}
+
+function generateResearch(data) {
+  const pub = document.getElementById('pub-list');
+  const exp = document.getElementById('exp-list');
+  if (pub) {
+    pub.innerHTML = '<ul>' + data.publications.map(p => `<li>${p.authors || ''} ${p.title || ''}</li>`).join('') + '</ul>';
+  }
+  if (exp) {
+    exp.innerHTML = data.experience.map(e => `
+      <div class="card">
+        <h3>${e.lab}</h3>
+        <p>${e.position}</p>
+        <p>${e.period}</p>
+        ${e.details ? '<ul>' + e.details.map(d => `<li>${d}</li>`).join('') + '</ul>' : ''}
+      </div>
+    `).join('');
+  }
+}
+
+async function init() {
+  initNavigation();
+  initSpotlight();
+  generateHome(await fetchJSON('data/home.json'));
+  generateEducation(await fetchJSON('data/education.json'));
+  generateProjects(await fetchJSON('data/projects.json'));
+  generateTeaching(await fetchJSON('data/teaching.json'));
+  generateResearch(await fetchJSON('data/research.json'));
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- update accent color and profile image size
- add large geometric background icon with parallax effect
- shrink spotlight halo and make header more transparent
- remove card backgrounds and reflow projects to a flex layout
- enlarge contact icons and center them

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6881d4152aa0832abde5670f73ce4308